### PR TITLE
Product selection fix

### DIFF
--- a/wc_return_product.php
+++ b/wc_return_product.php
@@ -96,7 +96,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
       $order_id = ($order != null) ? $_POST['order'] : false;
 
       // check if selected some product
-      if ( count($_POST['wc_products']) == 0  ) {
+      if ( !is_array($_POST['wc_products'])  ) {
         $json['response'] = __('You must select some product','wc_return');
       }
       else if ( !$to ) {


### PR DESCRIPTION
The if on line 99 was checking the count of the array position but based on my testing, if you don't select any option/product, the $_POST variable comes as empty ("") which fails the count() evaluation which allows clients to submit a return request without actually selecting the product, but when you actually choose any, despite the number of products you choose, the $_POST variable always comes as an array, so I changed the evaluation from count() to !is_array(), which means, if it isn't an array, no product is selected.